### PR TITLE
removed concat asset include

### DIFF
--- a/copy_this/modules/agcookiecompliance/application/views/tpl/widget/cookiecompliance.tpl
+++ b/copy_this/modules/agcookiecompliance/application/views/tpl/widget/cookiecompliance.tpl
@@ -37,7 +37,7 @@
 [{/strip}]
 [{/capture}]
 [{oxscript add=$complianceSettings}]
-[{oxscript include=$oViewConf->getModuleUrl('agcookiecompliance')|cat:'out/js/agcookiecompliance.min.js'}]
+[{oxscript include=$oViewConf->getModuleUrl('agcookiecompliance', 'out/js/agcookiecompliance.min.js')}]
 [{oxid_include_dynamic file="widget/cookiecompliancedialog.tpl"}]
 [{if $oViewConf->getCookieComplianceModuleSetting('blTrainingMode')}]
 [{capture assign=trainingScript}]

--- a/copy_this/modules/agcookiecompliance/views/blocks/base_style.tpl
+++ b/copy_this/modules/agcookiecompliance/views/blocks/base_style.tpl
@@ -1,4 +1,4 @@
-[{oxstyle include=$oViewConf->getModuleUrl('agcookiecompliance')|cat:'out/css/agcookiecompliance.min.css'}]
+[{oxstyle include=$oViewConf->getModuleUrl('agcookiecompliance', 'out/css/agcookiecompliance.min.css')}]
 <style>
     .cc-window {
         background-color: [{$oViewConf->getCookieComplianceModuleSetting('sBannerBackgroundColor')}];


### PR DESCRIPTION
Using the cat filter in asset includes caused wrong pathes when using other modules that added a filetime param like:
/modules/agcookiecompliance/?1596899221out/css/agcookiecompliance.min.css 

Offending module here was: https://bitbucket.org/therealworld/tools-plugin :)

Using the sFile param of getModuleUrl fixed it.